### PR TITLE
fix: cover metadata wrong endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/cover",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Cover Software Development Kit",
   "main": "./lib/cjs/index",
   "module": "./lib/esm/index",

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -185,7 +185,7 @@ export class Cover {
 
   async buildWithCoverMetadata(canisterId: string, repoAccessToken: string): Promise<void> {
     return validatorAxios
-      .post(`${this.config.validatorUrl}/build-with-config`, {
+      .post(`${this.config.validatorUrl}/build-with-cover-metadata`, {
         canisterId,
         repoAccessToken
       })


### PR DESCRIPTION
## Why?

fix: cover metadata wrong endpoint

## How?

- fix: cover metadata wrong endpoint

## Tickets?

- N/A

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [x] Documentation has been updated to reflect the changes
- [x] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass
- [x] All tests pass

## Security checklist?

- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The UI is escaping output (to prevent XSS)
- [x] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
